### PR TITLE
document default fastcmd behaviour

### DIFF
--- a/R/poridge.R
+++ b/R/poridge.R
@@ -211,7 +211,7 @@ pco_predict_preprocess <- function(model, newdata=NULL, dist_list){
 #' The list \code{xt} also has the following optional elements:
 #' \itemize{
 #'   \item \code{add}: Passed to \code{\link{cmdscale}} when performing multidimensional scaling; for details, see the help for that function. (Default \code{FALSE}.)\cr
-#'    \item \code{fastcmd}: if \code{TRUE}, multidimensional scaling is performed by \code{\link{cmdscale_lanczos}}, which uses Lanczos iteration to eigendecompose the distance matrix; if \code{FALSE}, MDS is carried out by \code{\link{cmdscale}}.
+#' \item \code{fastcmd}: if \code{TRUE}, multidimensional scaling is performed by \code{\link{cmdscale_lanczos}}, which uses Lanczos iteration to eigendecompose the distance matrix; if \code{FALSE}, MDS is carried out by \code{\link{cmdscale}}. Default is \code{FALSE}, to use \code{cmdscale}.
 #' }
 #'
 #' @author David L Miller, based on code from Lan Huo and Phil Reiss

--- a/man/smooth.construct.pco.smooth.spec.Rd
+++ b/man/smooth.construct.pco.smooth.spec.Rd
@@ -35,7 +35,7 @@ In a \code{\link[mgcv]{gam}} term of the above form \code{s(dummy, bs="pco", k, 
 The list \code{xt} also has the following optional elements:
 \itemize{
   \item \code{add}: Passed to \code{\link{cmdscale}} when performing multidimensional scaling; for details, see the help for that function. (Default \code{FALSE}.)\cr
-   \item \code{fastcmd}: if \code{TRUE}, multidimensional scaling is performed by \code{\link{cmdscale_lanczos}}, which uses Lanczos iteration to eigendecompose the distance matrix; if \code{FALSE}, MDS is carried out by \code{\link{cmdscale}}.
+\item \code{fastcmd}: if \code{TRUE}, multidimensional scaling is performed by \code{\link{cmdscale_lanczos}}, which uses Lanczos iteration to eigendecompose the distance matrix; if \code{FALSE}, MDS is carried out by \code{\link{cmdscale}}. Default is \code{FALSE}, to use \code{cmdscale}.
 }
 }
 \examples{


### PR DESCRIPTION
Minor documentation adjustment to let users know whether a Lanczos-based MDS calculation should be done rather than using R's builtin `cmdscale`.

Sorry, this should have gone in a previous PR. Also, I think you probably got a Travis notification for this.
