### PR TITLE
Update plot.fosr.perm.R

### DIFF
--- a/R/plot.fosr.perm.R
+++ b/R/plot.fosr.perm.R
@@ -1,7 +1,7 @@
 #' @export
 #' @rdname fosr.perm
 plot.fosr.perm <-
-function(x, level=.05, xlabel="", title=NULL,...) {
+function(x, level=NULL, xlabel="", title=NULL,...) {
 	if (is.null(level)) {
 		if (is.null(x$level)) stop("Must specify level at which to test")
 		else testobj = x


### PR DESCRIPTION
Replacing the default argument “level = 0.05” in plot.fosr.perm by “level = NULL” may make it read the default level directly and solve the problem that cannot tune the level from the plot embedded in the fosr.perm.