### PR TITLE
fixed a small bug in mfpca.face

### DIFF
--- a/R/face.Cov.mfpca.R
+++ b/R/face.Cov.mfpca.R
@@ -106,7 +106,7 @@ face.Cov.mfpca <- function(Y, argvals, A0, B, Anew, Bnew, G_invhalf, s, Cov=FALS
     ########   data imputation      #########
     #########################################
     if(imputation) {
-      Phi.N <- Phi[,1:N]
+      Phi.N <- Phi[,1:N, drop = FALSE]
       A.N <- G_invhalf %*% A[,1:N]
       d <- Sigma[1:N]
       sigmahat2  <-  max(mean(Y[!Index.miss]^2) -sum(Sigma),0)
@@ -122,7 +122,7 @@ face.Cov.mfpca <- function(Y, argvals, A0, B, Anew, Bnew, G_invhalf, s, Cov=FALS
     
   } ## end of while loop
   
-  Phi.N <- Phi[,1:N]
+  Phi.N <- Phi[,1:N, drop = FALSE]
   evalues <- Sigma[1:N]
   Ktilde <- NULL
   if(Cov) {

--- a/R/mfpca.face.R
+++ b/R/mfpca.face.R
@@ -4,7 +4,7 @@
 #' functional principal component analysis with the fast covariance estimation 
 #' approach. 
 #' 
-#' The fast MFPCA approach (Cui et al., 2022+) uses FACE (Xiao et al., 2016) to estimate 
+#' The fast MFPCA approach (Cui et al., 2023) uses FACE (Xiao et al., 2016) to estimate 
 #' covariance functions and mixed model equations (MME) to predict 
 #' scores for each level. As a result, it has lower computational complexity than 
 #' MFPCA (Di et al., 2009) implemented in the \code{mfpca.sc} function, and
@@ -54,12 +54,13 @@
 #' 
 #' @author Ruonan Li \email{rli20@@ncsu.edu}, Erjia Cui \email{ecui1@@jhmi.edu}
 #' 
-#' @references Cui, E., Li, R., Crainiceanu, C., and Xiao, L. (2022+). Fast multilevel
-#' functional principal component analysis.
+#' @references Cui, E., Li, R., Crainiceanu, C., and Xiao, L. (2023). Fast multilevel
+#' functional principal component analysis. \emph{Journal of Computational and 
+#' Graphical Statistics}, 32(3), 366-377.
 #' 
 #' Di, C., Crainiceanu, C., Caffo, B., and Punjabi, N. (2009).
 #' Multilevel functional principal component analysis. \emph{Annals of Applied
-#' Statistics}, 3, 458--488.
+#' Statistics}, 3, 458-488.
 #' 
 #' Xiao, L., Ruppert, D., Zipunnikov, V., and Crainiceanu, C. (2016).
 #' Fast covariance estimation for high-dimensional functional data.  

--- a/man/mfpca.face.Rd
+++ b/man/mfpca.face.Rd
@@ -78,7 +78,7 @@ functional principal component analysis with the fast covariance estimation
 approach.
 }
 \details{
-The fast MFPCA approach (Cui et al., 2022+) uses FACE (Xiao et al., 2016) to estimate 
+The fast MFPCA approach (Cui et al., 2023) uses FACE (Xiao et al., 2016) to estimate 
 covariance functions and mixed model equations (MME) to predict 
 scores for each level. As a result, it has lower computational complexity than 
 MFPCA (Di et al., 2009) implemented in the \code{mfpca.sc} function, and
@@ -90,12 +90,13 @@ data(DTI)
 mfpca.DTI <- mfpca.face(Y = DTI$cca, id = DTI$ID, twoway = TRUE)
 }
 \references{
-Cui, E., Li, R., Crainiceanu, C., and Xiao, L. (2022+). Fast multilevel
-functional principal component analysis.
+Cui, E., Li, R., Crainiceanu, C., and Xiao, L. (2023). Fast multilevel
+functional principal component analysis. \emph{Journal of Computational and 
+Graphical Statistics}, 32(3), 366-377.
 
 Di, C., Crainiceanu, C., Caffo, B., and Punjabi, N. (2009).
 Multilevel functional principal component analysis. \emph{Annals of Applied
-Statistics}, 3, 458--488.
+Statistics}, 3, 458-488.
 
 Xiao, L., Ruppert, D., Zipunnikov, V., and Crainiceanu, C. (2016).
 Fast covariance estimation for high-dimensional functional data.  


### PR DESCRIPTION
Fixed a small bug in mfpca.face(), that occurs when only one eigenfunction explains all the variance in the within-subject covariance structure. This bug can be easily fixed by changing Phi.N <- Phi[,1:N] to Phi.N <- Phi[,1:N, drop = FALSE] in the face.Cov.mfpca() function. We would like to thank Edward.Gunning <Edward.Gunning@ul.ie> for raising this issue and providing a quick fix.