### PR TITLE
rank-guard: effective-rank diagnostic for ff() covariates (S-I)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,10 +47,13 @@ Imports:
     pbs,
     methods
 Suggests:
+    knitr,
     RColorBrewer,
     reshape2,
+    rmarkdown,
     sandwich,
     testthat
+VignetteBuilder: knitr
 Description: Methods for regression for functional
     data, including function-on-scalar, scalar-on-function, and
     function-on-function regression. Some of the functions are applicable to

--- a/NEWS.md
+++ b/NEWS.md
@@ -59,10 +59,15 @@
   interval coverage alike, without any fitting failure -- passed silently.
   The hard `rank < k_s` case is now reported as part of the same warning.
   See the "Effective rank and weak identifiability" section of `?ff` and the
-  `ff-identifiability` vignette. Note that the functional covariate produced
-  by `pffr_simulate()` has effective rank 5 and therefore trips the new
-  warning at `ff()`'s default `k = c(5, 5)`; that is a property of the
-  simulated covariate, not a false positive.
+  `ff-identifiability` vignette.
+* The functional covariate simulated by `pffr_simulate()`'s legacy
+  `scenario =` path is now drawn from a 12- rather than 7-dimensional spline
+  basis, **doubling its effective rank from 5 to 10**. At the old rank the
+  package's own simulated covariate was weakly identified against `ff()`'s
+  default `k = 5` (which wants at least 7.5) and tripped the new warning
+  above. The formula interface was already well clear of the threshold
+  (effective rank 13-22, depending on `nxgrid`) and is unchanged. Simulated
+  data from the `scenario =` path therefore differ from earlier versions.
 * AR(1) support improvements: `pffr()` now automatically switches to
   `algorithm = "bam"` and `method = "fREML"` when `rho` is supplied, and
   sets `discrete = TRUE` for non-Gaussian families.

--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,19 @@
   report CL2 leverage diagnostics: the returned covariance carries
   `max_leverage` and `n_capped_clusters` attributes, and a warning is emitted
   when one or more clusters hit the leverage cap.
+* `ff(..., check.ident = TRUE)` (the default) now also warns when the
+  effective rank of the functional covariate's covariance is below
+  `1.5 * k_s`, where `k_s` is the marginal basis dimension along `s`. The
+  previous check only fired at the much weaker `rank < k_s`, so designs in
+  which a sizeable part of the coefficient surface lies outside the span of
+  the observed curves -- a bias floor that affects point estimates and
+  interval coverage alike, without any fitting failure -- passed silently.
+  The hard `rank < k_s` case is now reported as part of the same warning.
+  See the "Effective rank and weak identifiability" section of `?ff` and the
+  `ff-identifiability` vignette. Note that the functional covariate produced
+  by `pffr_simulate()` has effective rank 5 and therefore trips the new
+  warning at `ff()`'s default `k = c(5, 5)`; that is a property of the
+  simulated covariate, not a false positive.
 * AR(1) support improvements: `pffr()` now automatically switches to
   `algorithm = "bam"` and `method = "fREML"` when `rho` is supplied, and
   sets `discrete = TRUE` for non-Gaussian families.

--- a/R/pffr-ff.R
+++ b/R/pffr-ff.R
@@ -27,6 +27,38 @@
 #' \eqn{X_i(s)}) is lower than 4. If \eqn{X_i(s)} is of very low rank,
 #' \code{\link{ffpc}}-term may be preferable.
 #'
+#' @section Effective rank and weak identifiability:
+#'
+#' \code{check.ident} also compares the effective rank of Cov\eqn{(X(s))}
+#' against the marginal basis dimension \eqn{k_s} used for \eqn{\beta(t,s)}
+#' along \eqn{s} (i.e. \code{splinepars$k[1]}), and warns whenever the
+#' effective rank is below \eqn{1.5 k_s}. The hard case \eqn{\mathrm{rank} <
+#' k_s} (the surface is identified through the penalty alone) is a special case
+#' of this warning and is flagged explicitly in its message.
+#'
+#' The reason for the margin is that identifiability is not a yes/no property
+#' here: the data only inform \eqn{\beta(t,s)} in directions that the observed
+#' curves span. Once \eqn{k_s} approaches the effective rank, an appreciable
+#' part of a rough true surface lies outside that span, and this component is
+#' returned by the penalty rather than estimated. It is a shared bias floor: it
+#' affects every estimator and every kind of standard error, so both point
+#' estimates and interval coverage for the \code{ff} term become hard to
+#' interpret, and it does not show up as a fitting failure. A factor of about
+#' 1.5 was the smallest margin at which this contamination was negligible in
+#' the simulation studies behind the cluster-robust \code{\link{pffr}}
+#' intervals.
+#'
+#' The effective rank can never exceed \code{min(nrow(X), ncol(X))}, so with
+#' few curves the warning may be impossible to satisfy at the requested
+#' \eqn{k_s}. Remedies, in order of preference: lower \eqn{k_s} (via
+#' \code{splinepars = list(k = c(k_s, k_t))}); use more or more varied curves;
+#' switch to \code{\link{ffpc}}, which parameterizes the effect in the leading
+#' functional principal components of \eqn{X} and is designed for the low-rank
+#' case. If none of these is possible, the fit is still usable, but conclusions
+#' about \eqn{\beta(t,s)} -- including the width and coverage of its confidence
+#' bands -- should be drawn with that caveat in mind. The check can be switched
+#' off with \code{check.ident = FALSE}.
+#'
 #' @param X an n by \code{ncol(xind)} matrix of function evaluations
 #'   \eqn{X_i(s_{i1}),\dots, X_i(s_{iS})}; \eqn{i=1,\dots,n}.
 #' @param yind \emph{DEPRECATED} used to supply matrix (or vector) of indices of
@@ -182,7 +214,12 @@ ff <- function(
     ## check whether (number of basis functions) < (number of relevant eigenfunctions of X)
     evX <- svd(X, nu = 0, nv = 0)$d^2
     maxK <- max(1, min(which((cumsum(evX) / sum(evX)) >= .995)))
-    bsdim <- eval(call)$margin[[1]]$bs.dim
+    term_spec <- eval(call)
+    bsdim <- if (!is.null(term_spec$margin)) {
+      term_spec$margin[[1]]$bs.dim
+    } else {
+      term_spec$bs.dim
+    }
     if (maxK <= 4)
       warning(
         "Very low effective rank of <",
@@ -192,12 +229,43 @@ ff <- function(
         " largest eigenvalues of its covariance alone account for >99.5% of ",
         "variability. <ffpc> might be a better choice here."
       )
-    if (maxK < bsdim) {
-      warning(
-        "<k> larger than effective rank of <",
-        deparse(match.call()$X),
-        ">. Model identifiable only through penalty."
-      )
+    ## Weak-identifiability guard. The effective rank of Cov(X(s)) has to
+    ## exceed the marginal basis dimension along s comfortably, not merely
+    ## match it: maxK < bsdim is the hard case (the surface is pinned down by
+    ## the penalty alone), while maxK < 1.5 * bsdim is the practical margin
+    ## below which part of beta(t, s) lies outside the span of the observed
+    ## curves and is therefore not estimable from the data.
+    if (length(bsdim) == 1 && is.finite(bsdim) && bsdim > 0) {
+      if (maxK < 1.5 * bsdim) {
+        warning(
+          "Effective rank of <",
+          deparse(match.call()$X),
+          "> is ",
+          maxK,
+          ", below 1.5 * k = ",
+          format(1.5 * bsdim),
+          " for the k = ",
+          bsdim,
+          " basis functions along <s>",
+          if (maxK < bsdim) {
+            paste0(
+              "; <k> is larger than the effective rank, so the model is ",
+              "identifiable only through the penalty"
+            )
+          } else {
+            ""
+          },
+          ". The coefficient surface is only weakly identified: components of ",
+          "beta(t, s) in directions the observed curves do not span are ",
+          "determined by the penalty alone, so estimates can be biased and ",
+          "interval coverage unreliable in those directions. Reduce k along ",
+          "<s>, or use more / richer curves -- the effective rank cannot ",
+          "exceed min(nrow(X), ncol(X)) = ",
+          min(n, nxgrid),
+          ". See ?ff (Details) and Scheipl & Greven (2016).",
+          call. = FALSE
+        )
+      }
     }
     if (basistype != "s") {
       # check whether span(Null(X)), span(L * B_s%*%Null(penalty)) are disjunct:

--- a/R/pffr-simulate.R
+++ b/R/pffr-simulate.R
@@ -263,7 +263,11 @@ pffrSim <- function(
 #'
 #' Internal function preserving the original pffr_simulate behavior for backward
 #' compatibility. This is called when the deprecated \code{scenario} argument
-#' is used.
+#' is used. One deliberate departure from the original: the basis dimension
+#' used to draw the functional covariate was raised from 7 to 12, doubling its
+#' effective rank from 5 to 10, so that the simulated covariate is not itself
+#' weakly identified against ff()'s default basis (see \code{\link{ff}}).
+#' Simulated data from this path therefore differ from pre-0.1-40 draws.
 #'
 #' @inheritParams pffr_simulate
 #' @keywords internal
@@ -279,7 +283,12 @@ pffrSim_legacy <- function(
   mc <- match.call()
 
   ## generates random functions...
-  rf <- function(x = seq(0, 1, length = 100), bs.dim = 7, center = FALSE) {
+  ## bs.dim was 7, which gave the simulated X1 an effective rank of only 5 --
+  ## below 1.5 * k even for ff()'s default k = 5, so the package's own
+  ## simulated covariate tripped the weak-identifiability warning in ?ff.
+  ## bs.dim = 12 doubles the effective rank to 10 (stable across draws at the
+  ## default n = 100, nxgrid = 40).
+  rf <- function(x = seq(0, 1, length = 100), bs.dim = 12, center = FALSE) {
     nk <- bs.dim - 2
     xu <- max(x)
     xl <- min(x)

--- a/man/ff.Rd
+++ b/man/ff.Rd
@@ -97,6 +97,40 @@ of eigenvalues accounting for at least 0.995 of the total variance in
 \eqn{X_i(s)}) is lower than 4. If \eqn{X_i(s)} is of very low rank,
 \code{\link{ffpc}}-term may be preferable.
 }
+\section{Effective rank and weak identifiability}{
+
+
+\code{check.ident} also compares the effective rank of Cov\eqn{(X(s))}
+against the marginal basis dimension \eqn{k_s} used for \eqn{\beta(t,s)}
+along \eqn{s} (i.e. \code{splinepars$k[1]}), and warns whenever the
+effective rank is below \eqn{1.5 k_s}. The hard case \eqn{\mathrm{rank} <
+k_s} (the surface is identified through the penalty alone) is a special case
+of this warning and is flagged explicitly in its message.
+
+The reason for the margin is that identifiability is not a yes/no property
+here: the data only inform \eqn{\beta(t,s)} in directions that the observed
+curves span. Once \eqn{k_s} approaches the effective rank, an appreciable
+part of a rough true surface lies outside that span, and this component is
+returned by the penalty rather than estimated. It is a shared bias floor: it
+affects every estimator and every kind of standard error, so both point
+estimates and interval coverage for the \code{ff} term become hard to
+interpret, and it does not show up as a fitting failure. A factor of about
+1.5 was the smallest margin at which this contamination was negligible in
+the simulation studies behind the cluster-robust \code{\link{pffr}}
+intervals.
+
+The effective rank can never exceed \code{min(nrow(X), ncol(X))}, so with
+few curves the warning may be impossible to satisfy at the requested
+\eqn{k_s}. Remedies, in order of preference: lower \eqn{k_s} (via
+\code{splinepars = list(k = c(k_s, k_t))}); use more or more varied curves;
+switch to \code{\link{ffpc}}, which parameterizes the effect in the leading
+functional principal components of \eqn{X} and is designed for the low-rank
+case. If none of these is possible, the fit is still usable, but conclusions
+about \eqn{\beta(t,s)} -- including the width and coverage of its confidence
+bands -- should be drawn with that caveat in mind. The check can be switched
+off with \code{check.ident = FALSE}.
+}
+
 \references{
 For background on \code{check.ident}:\cr Scheipl, F., Greven,
   S. (2016). Identifiability in penalized function-on-function regression

--- a/man/pffrSim_legacy.Rd
+++ b/man/pffrSim_legacy.Rd
@@ -36,6 +36,10 @@ e.g., \code{function(s, t) s < t}.}
 \description{
 Internal function preserving the original pffr_simulate behavior for backward
 compatibility. This is called when the deprecated \code{scenario} argument
-is used.
+is used. One deliberate departure from the original: the basis dimension
+used to draw the functional covariate was raised from 7 to 12, doubling its
+effective rank from 5 to 10, so that the simulated covariate is not itself
+weakly identified against ff()'s default basis (see \code{\link{ff}}).
+Simulated data from this path therefore differ from pre-0.1-40 draws.
 }
 \keyword{internal}

--- a/tests/testthat/test-pffr-ff-rank.R
+++ b/tests/testthat/test-pffr-ff-rank.R
@@ -1,0 +1,91 @@
+#--------------------------------------
+# ff() effective-rank / weak-identifiability guard
+#--------------------------------------
+#
+# ff(check.ident = TRUE) warns when the effective rank of Cov(X(s)) --- the
+# number of eigenvalues covering >= 99.5% of the variance --- falls below
+# 1.5 * k_s, the marginal basis dimension along s. The historical check only
+# fired at the much weaker rank < k_s, so weakly identified designs (part of
+# beta(t, s) outside the span of the observed curves) were silent.
+
+# n curves spanned by `rank` smooth components: effective rank ~ `rank`.
+low_rank_curves <- function(n, s, rank, sd_decay = 0.9) {
+  scores <- matrix(
+    rnorm(n * rank, sd = rep(sd_decay^(seq_len(rank) - 1), each = n)),
+    n,
+    rank
+  )
+  basis <- sapply(seq_len(rank), function(j) sin(j * pi * s))
+  scores %*% t(basis)
+}
+
+test_that("ff() warns when the effective rank is below 1.5 * k_s", {
+  set.seed(20260804)
+  s <- seq(0, 1, length.out = 40)
+  X <- low_rank_curves(40, s, rank = 5)
+
+  expect_warning(
+    ff(X, xind = s, splinepars = list(bs = "ps", k = c(8, 5))),
+    "Effective rank of <X>"
+  )
+  # message carries both numbers and the threshold
+  w <- tryCatch(
+    ff(X, xind = s, splinepars = list(bs = "ps", k = c(8, 5))),
+    warning = conditionMessage
+  )
+  expect_match(w, "below 1.5 \\* k = 12")
+  expect_match(w, "k = 8 basis functions")
+  expect_match(w, "weakly identified")
+})
+
+test_that("the hard rank < k_s case is flagged inside the same warning", {
+  set.seed(20260805)
+  s <- seq(0, 1, length.out = 40)
+  # rank ~ 6 (above the separate "very low rank" warning at <= 4) vs k_s = 10
+  X <- low_rank_curves(40, s, rank = 6, sd_decay = 1)
+
+  w <- tryCatch(
+    ff(X, xind = s, splinepars = list(bs = "ps", k = c(10, 5))),
+    warning = conditionMessage
+  )
+  expect_match(w, "identifiable only through the penalty")
+})
+
+test_that("ff() does not warn when the effective rank clears 1.5 * k_s", {
+  set.seed(20260806)
+  s <- seq(0, 1, length.out = 40)
+  # rank ~ 15 against k_s = 5 (needs 7.5)
+  X <- low_rank_curves(60, s, rank = 15, sd_decay = 1)
+
+  expect_no_warning(
+    ff(X, xind = s, splinepars = list(bs = "ps", k = c(5, 5)))
+  )
+})
+
+test_that("check.ident = FALSE switches the guard off", {
+  set.seed(20260804)
+  s <- seq(0, 1, length.out = 40)
+  X <- low_rank_curves(40, s, rank = 5)
+
+  expect_no_warning(
+    ff(
+      X,
+      xind = s,
+      splinepars = list(bs = "ps", k = c(8, 5)),
+      check.ident = FALSE
+    )
+  )
+})
+
+test_that("the guard survives a rank cap set by the number of curves", {
+  set.seed(20260807)
+  s <- seq(0, 1, length.out = 40)
+  # only 6 curves: effective rank <= 6 no matter how rich the generator is
+  X <- low_rank_curves(6, s, rank = 20, sd_decay = 1)
+
+  w <- tryCatch(
+    ff(X, xind = s, splinepars = list(bs = "ps", k = c(8, 5))),
+    warning = conditionMessage
+  )
+  expect_match(w, "cannot exceed min\\(nrow\\(X\\), ncol\\(X\\)\\) = 6")
+})

--- a/vignettes/ff-identifiability.Rmd
+++ b/vignettes/ff-identifiability.Rmd
@@ -1,0 +1,71 @@
+---
+title: "Effective rank and weak identifiability in ff() terms"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Effective rank and weak identifiability in ff() terms}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+```
+
+A function-on-function term `ff(X, xind = s)` estimates a coefficient surface
+$\beta(t,s)$, but the data only inform $\beta$ in directions along $s$ that the
+observed curves $X_i(s)$ actually span. `ff()` measures that span by the
+*effective rank* of $\mathrm{Cov}(X(s))$: the number of eigenvalues needed to
+account for 99.5% of the variance in `X`. With `check.ident = TRUE` (the
+default) `ff()` warns when this effective rank falls below `1.5 * k_s`, where
+`k_s` is the marginal basis dimension along `s`.
+
+```{r, message = FALSE}
+library(refund)
+set.seed(1)
+s <- seq(0, 1, length.out = 40)
+# 30 curves built from only 5 Fourier components: effective rank ~ 5
+scores <- matrix(rnorm(30 * 5), 30, 5)
+basis <- sapply(1:5, function(j) sin(j * pi * s))
+X <- scores %*% t(basis)
+
+term <- try(ff(X, xind = s, splinepars = list(bs = "ps", k = c(8, 5))))
+```
+
+## Why 1.5, and what the warning means
+
+Identifiability here is not a yes/no property. The stricter of the two
+classical conditions, effective rank $< k_s$, means the surface is pinned down
+by the penalty alone. But the problem starts well before that point: as $k_s$
+approaches the effective rank, a growing part of a rough true surface lies
+outside the span of the observed curves, and the fit returns the penalty's
+answer for that component instead of an estimate.
+
+This is a *shared bias floor*. It is not specific to one estimator or one kind
+of standard error, so it degrades point estimates and interval coverage
+together, and — the reason for the warning — it produces no fitting failure and
+no visible symptom. In the simulation studies behind `pffr()`'s cluster-robust
+intervals, a margin of about a factor 1.5 was the smallest at which this
+contamination was negligible; below it, several percent of the true surface's
+energy was unreachable by any method.
+
+## What to do about it
+
+* **Lower `k_s`**, via `splinepars = list(bs = "ps", k = c(k_s, k_t))`. This is
+  usually the right response: a basis the curves cannot support is not buying
+  flexibility, only penalty-driven fill-in.
+* **Use more, or more varied, curves.** The effective rank can never exceed
+  `min(nrow(X), ncol(X))`, so with few curves the warning may be impossible to
+  satisfy at the requested `k_s` — the design, not the code, is the binding
+  constraint.
+* **Switch to `ffpc()`**, which parameterizes the effect in the leading
+  functional principal components of `X` and is built for the genuinely
+  low-rank case.
+* If none of these is available, the fit remains usable — but conclusions about
+  $\beta(t,s)$, including the width and coverage of its confidence bands,
+  inherit the caveat. Report it.
+
+The check can be switched off with `check.ident = FALSE`.
+
+See `?ff` and Scheipl, F., Greven, S. (2016). Identifiability in penalized
+function-on-function regression models. *Electronic Journal of Statistics*
+**10**(1), 495–526.


### PR DESCRIPTION
Merges the rank-guard branch (2 commits: the ff() effective-rank warning and pffr_simulate() covariate rank 5 -> 10) into pffr-refactor after the exact-CL2 merge. Validated in the pffr-ci benchmark program (plan item S-I).

🤖 Generated with [Claude Code](https://claude.com/claude-code)